### PR TITLE
Add next meeting field to Person class

### DIFF
--- a/docs/DeveloperGuide.md
+++ b/docs/DeveloperGuide.md
@@ -45,7 +45,24 @@ The bulk of the app's work is done by the following four components:
 
 ## **Implementation**
 
-(Keep as in AB3 DG unless you have already added new features.)
+### Next meeting field
+
+The next meeting information is modelled as a dedicated value object (`seedu.address.model.person.NextMeeting`) so that validation, defaults, and equality checks stay consistent across the code base.
+
+**Parsing workflow**
+- `CliSyntax.PREFIX_NEXT_MEETING (m/)` marks the optional input.
+- `AddCommandParser` falls back to `NextMeeting.DEFAULT_VALUE` (`"No meeting scheduled"`) when the prefix is absent, while `ParserUtil.parseNextMeeting` trims and validates non-empty input.
+- `EditCommandParser` maps the prefix into `EditCommand.EditPersonDescriptor`, enabling partial updates during `edit`.
+
+**Model and storage**
+- `Person` stores a `NextMeeting` instance alongside existing identity and data fields.
+- `JsonAdaptedPerson` serialises/deserialises the value, substituting the default string when the JSON omits the field so older save files continue to load.
+- `SampleDataUtil` provides illustrative values so that the UI demonstrates the field out of the box.
+
+**UI**
+- `PersonCard` now renders a `nextMeeting` label inside `PersonListCard.fxml`, showing `Next meeting: <value>` so users can see at-a-glance follow-up details.
+
+Automated coverage lives in `AddCommandParserTest`, `EditCommandParserTest`, `ParserUtilTest`, and `PersonTest`, ensuring the prefix behaves correctly, invalid values are rejected, and equality semantics include the new field.
 
 --------------------------------------------------------------------------------------------------------------------
 

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -80,16 +80,18 @@ Format: `help`
 
 Adds a person to the address book.
 
-Format: `add n/NAME p/PHONE_NUMBER e/EMAIL a/ADDRESS [t/TAG]…​`
+Format: `add n/NAME p/PHONE_NUMBER e/EMAIL a/ADDRESS [c/COMPANY] [m/NEXT_MEETING] [t/TAG]…​`
 
 <box type="tip" seamless>
 
 **Tip:** A person can have any number of tags (including 0)
 </box>
 
+If `m/NEXT_MEETING` is omitted, the person will default to `No meeting scheduled`.
+
 Examples:
 * `add n/John Doe p/98765432 e/johnd@example.com a/John street, block 123, #01-01`
-* `add n/Betsy Crowe t/friend e/betsycrowe@example.com a/Newgate Prison p/1234567 t/criminal`
+* `add n/Betsy Crowe p/1234567 e/betsycrowe@example.com a/Newgate Prison c/NUS m/Project sync on Friday t/friend t/criminal`
 
 ### Listing all persons : `list`
 
@@ -101,7 +103,7 @@ Format: `list`
 
 Edits an existing person in the address book.
 
-Format: `edit INDEX [n/NAME] [p/PHONE] [e/EMAIL] [a/ADDRESS] [t/TAG]…​`
+Format: `edit INDEX [n/NAME] [p/PHONE] [e/EMAIL] [a/ADDRESS] [c/COMPANY] [m/NEXT_MEETING] [t/TAG]…​`
 
 * Edits the person at the specified `INDEX`. The index refers to the index number shown in the displayed person list. The index **must be a positive integer** 1, 2, 3, …​
 * At least one of the optional fields must be provided.
@@ -112,7 +114,8 @@ Format: `edit INDEX [n/NAME] [p/PHONE] [e/EMAIL] [a/ADDRESS] [t/TAG]…​`
 
 Examples:
 *  `edit 1 p/91234567 e/johndoe@example.com` Edits the phone number and email address of the 1st person to be `91234567` and `johndoe@example.com` respectively.
-*  `edit 2 n/Betsy Crower t/` Edits the name of the 2nd person to be `Betsy Crower` and clears all existing tags.
+*  `edit 2 m/No meeting scheduled` Resets the next meeting of the 2nd person to the default message.
+*  `edit 3 n/Betsy Crower t/` Edits the name of the 3rd person to be `Betsy Crower` and clears all existing tags.
 
 ### Locating persons by name: `find`
 
@@ -197,10 +200,10 @@ _Details coming soon ..._
 
 Action     | Format, Examples
 -----------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------
-**Add**    | `add n/NAME p/PHONE_NUMBER e/EMAIL a/ADDRESS [t/TAG]…​` <br> e.g., `add n/James Ho p/22224444 e/jamesho@example.com a/123, Clementi Rd, 1234665 t/friend t/colleague`
+**Add**    | `add n/NAME p/PHONE_NUMBER e/EMAIL a/ADDRESS [c/COMPANY] [m/NEXT_MEETING] [t/TAG]…​` <br> e.g., `add n/James Ho p/22224444 e/jamesho@example.com a/123, Clementi Rd, 1234665 c/Acme Corp m/Catch up next Tue t/friend t/colleague`
 **Clear**  | `clear`
 **Delete** | `delete INDEX`<br> e.g., `delete 3`
-**Edit**   | `edit INDEX [n/NAME] [p/PHONE_NUMBER] [e/EMAIL] [a/ADDRESS] [t/TAG]…​`<br> e.g.,`edit 2 n/James Lee e/jameslee@example.com`
+**Edit**   | `edit INDEX [n/NAME] [p/PHONE_NUMBER] [e/EMAIL] [a/ADDRESS] [c/COMPANY] [m/NEXT_MEETING] [t/TAG]…​`<br> e.g.,`edit 2 m/No meeting scheduled`
 **Find**   | `find KEYWORD [MORE_KEYWORDS]`<br> e.g., `find James Jake`
 **List**   | `list`
 **Help**   | `help`

--- a/src/main/java/seedu/address/ui/PersonCard.java
+++ b/src/main/java/seedu/address/ui/PersonCard.java
@@ -41,6 +41,8 @@ public class PersonCard extends UiPart<Region> {
     @FXML
     private Label company;
     @FXML
+    private Label nextMeeting;
+    @FXML
     private FlowPane tags;
 
     /**
@@ -56,6 +58,7 @@ public class PersonCard extends UiPart<Region> {
         email.setText(person.getEmail().value);
         company.setText(person.getCompany().value.isEmpty()
                 ? "" : "Company: " + person.getCompany().value);
+        nextMeeting.setText("Next meeting: " + person.getNextMeeting().value);
         person.getTags().stream()
                 .sorted(Comparator.comparing(tag -> tag.tagName))
                 .forEach(tag -> tags.getChildren().add(new Label(tag.tagName)));

--- a/src/main/resources/view/PersonListCard.fxml
+++ b/src/main/resources/view/PersonListCard.fxml
@@ -32,6 +32,7 @@
       <Label fx:id="address" styleClass="cell_small_label" text="\$address" />
       <Label fx:id="email" styleClass="cell_small_label" text="\$email" />
       <Label fx:id="company" styleClass="cell_small_label" text="\$company" />
+      <Label fx:id="nextMeeting" styleClass="cell_small_label" text="\$nextMeeting" />
     </VBox>
   </GridPane>
 </HBox>


### PR DESCRIPTION
## What
  Adds optional `m/` prefix for next meeting information to help users track upcoming meetings with contacts.

  ## Changes
  - Added `NextMeeting` field to `Person` model with validation
  - Updated `add` command to support optional `m/` prefix
  - Updated `edit` command to support modifying meeting info
  - UI displays "Next meeting: ..." for each contact
  - JSON storage backward-compatible with default value "No meeting scheduled"
  - Sample data includes example meeting times

  ## Testing
  - [x] All tests pass (`./gradlew test`)
  - [x] Manual testing completed (add/edit/display)
  - [x] UI screenshots attached below

  ## Documentation
  - [x] UserGuide updated with `m/` prefix examples
  - [x] DeveloperGuide added implementation section
 
  ## Screenshots

<img width="1244" height="1157" alt="1" src="https://github.com/user-attachments/assets/1b47e2e7-c0a8-47e9-b674-96c552e33fe9" />

<img width="1590" height="1148" alt="4" src="https://github.com/user-attachments/assets/202a326d-a5a3-4d49-b09c-e2fdd4bb4c7c" />


Closes #42 