### PR TITLE
Tag: canonicalize names for case-insensitive equality

### DIFF
--- a/src/main/java/seedu/address/model/tag/Tag.java
+++ b/src/main/java/seedu/address/model/tag/Tag.java
@@ -21,8 +21,9 @@ public class Tag {
      */
     public Tag(String tagName) {
         requireNonNull(tagName);
-        checkArgument(isValidTagName(tagName), MESSAGE_CONSTRAINTS);
-        this.tagName = tagName;
+        String normalized = tagName.trim();
+        checkArgument(isValidTagName(normalized), MESSAGE_CONSTRAINTS);
+        this.tagName = normalized.toLowerCase();
     }
 
     /**

--- a/src/test/java/seedu/address/logic/parser/AddCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddCommandParserTest.java
@@ -74,6 +74,16 @@ public class AddCommandParserTest {
     }
 
     @Test
+    public void parse_duplicateTagsWithDifferentCase_deduplicated() {
+        Person expectedPerson = new PersonBuilder(BOB).withNextMeeting(VALID_NEXT_MEETING_BOB)
+                .withTags(VALID_TAG_FRIEND).build();
+        assertParseSuccess(parser,
+                NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB + ADDRESS_DESC_BOB
+                        + NEXT_MEETING_DESC_BOB + TAG_DESC_FRIEND + " t/Friend",
+                new AddCommand(expectedPerson));
+    }
+
+    @Test
     public void parse_repeatedNonTagValue_failure() {
         String validExpectedPersonString = NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB
                 + ADDRESS_DESC_BOB + NEXT_MEETING_DESC_BOB + TAG_DESC_FRIEND;

--- a/src/test/java/seedu/address/model/tag/TagTest.java
+++ b/src/test/java/seedu/address/model/tag/TagTest.java
@@ -1,5 +1,6 @@
 package seedu.address.model.tag;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static seedu.address.testutil.Assert.assertThrows;
 
 import org.junit.jupiter.api.Test;
@@ -15,6 +16,20 @@ public class TagTest {
     public void constructor_invalidTagName_throwsIllegalArgumentException() {
         String invalidTagName = "";
         assertThrows(IllegalArgumentException.class, () -> new Tag(invalidTagName));
+    }
+
+    @Test
+    public void constructor_normalizesCase() {
+        Tag tag = new Tag("Friend");
+        assertEquals("friend", tag.tagName);
+    }
+
+    @Test
+    public void equals_caseInsensitive() {
+        Tag lower = new Tag("friend");
+        Tag mixed = new Tag("Friend");
+        assertEquals(lower, mixed);
+        assertEquals(lower.hashCode(), mixed.hashCode());
     }
 
     @Test


### PR DESCRIPTION
Fixes #135

Tag.java:23 canonicalizes names to lowercase; TagTest.java:20 and AddCommandParserTest.java:54 cover the new behaviour.