### PR TITLE
UG: add “Why CLI fits these users” paragraph and DG cross-reference

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -10,6 +10,11 @@ MeetCLI is a **desktop app for managing contacts and lightweight follow-up remin
 
 **Target Users**: Property agents, sales professionals, and business developers who need to manage large contact lists with company affiliations, tags, and a concise "next meeting" note.
 
+### Why a CLI fits these users
+Property agents and sales professionals rely on keyboard-driven workflows (rapid entry, batch filtering, repeatable scripts). MeetCLI optimizes for speed and automation, reducing friction during lead capture and follow-ups.
+
+See [Developer Guide → Appendix: Requirements → Target user profile](DeveloperGuide.html#target-user-profile) for the full user profile and underlying assumptions.
+
 --------------------------------------------------------------------------------------------------------------------
 
 ## Table of Contents


### PR DESCRIPTION
Fixes #128

    docs/UserGuide.md:11 adds “Why a CLI fits these users” and links to

    DeveloperGuide.html#target-user-profile.
